### PR TITLE
Integrate LUSE and ZAFSA placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # scientific-ai
 New generation AI
+
+## Data Pipeline
+The repository includes a `data_pipeline.py` script that fetches market data and prepares it for analysis. It now supports optional integration with the Lusaka Stock Exchange (LUSE) and ZAFSA data sources. To enable these integrations, set the following environment variables before running the pipeline:
+
+- `STOCK_API_KEY` – API key for the generic stock exchange endpoint
+- `GOLD_API_KEY` – API key for gold price data
+- `INFLATION_API_KEY` – API key for inflation data
+- `LUSE_API_KEY` – API key for LUSE stock data
+- `ZAFSA_API_KEY` – API key for ZAFSA market data
+
+Run the pipeline with:
+
+```bash
+python data_pipeline.py
+```
+
+The processed data is saved in the `data/` directory.

--- a/data_pipeline.py
+++ b/data_pipeline.py
@@ -7,9 +7,13 @@ from datetime import datetime
 STOCK_EXCHANGE_API = "https://api.example.com/stock_exchange"
 GOLD_PRICE_API = "https://api.example.com/gold_price"
 INFLATION_DATA_API = "https://api.example.com/inflation_data"
+LUSE_API = "https://api.luse.example.com/market_data"
+ZAFSA_API = "https://api.zafsa.example.com/market_data"
 
 # API keys (use environment variables for security)
 STOCK_API_KEY = os.getenv("STOCK_API_KEY")
+LUSE_API_KEY = os.getenv("LUSE_API_KEY")
+ZAFSA_API_KEY = os.getenv("ZAFSA_API_KEY")
 GOLD_API_KEY = os.getenv("GOLD_API_KEY")
 INFLATION_API_KEY = os.getenv("INFLATION_API_KEY")
 
@@ -37,6 +41,29 @@ def fetch_stock_data():
         print("Stock data saved.")
     else:
         print("Failed to fetch stock data.")
+
+
+def fetch_luse_stock_data():
+    """Fetch stock data from Lusaka Stock Exchange (LUSE)."""
+    params = {"api_key": LUSE_API_KEY}
+    data = fetch_data(LUSE_API, params)
+    if data:
+        df = pd.DataFrame(data)
+        df.to_csv(os.path.join(DATA_DIR, "luse_stock_data.csv"), index=False)
+        print("LUSE stock data saved.")
+    else:
+        print("Failed to fetch LUSE stock data.")
+
+def fetch_zafsa_data():
+    """Fetch market data from ZAFSA."""
+    params = {"api_key": ZAFSA_API_KEY}
+    data = fetch_data(ZAFSA_API, params)
+    if data:
+        df = pd.DataFrame(data)
+        df.to_csv(os.path.join(DATA_DIR, "zafsa_data.csv"), index=False)
+        print("ZAFSA data saved.")
+    else:
+        print("Failed to fetch ZAFSA data.")
 
 def fetch_gold_price_data():
     """Fetch gold price data."""
@@ -67,14 +94,24 @@ def preprocess_data():
         stock_data = pd.read_csv(os.path.join(DATA_DIR, "stock_data.csv"))
         gold_price_data = pd.read_csv(os.path.join(DATA_DIR, "gold_price_data.csv"))
         inflation_data = pd.read_csv(os.path.join(DATA_DIR, "inflation_data.csv"))
+        luse_data = pd.read_csv(os.path.join(DATA_DIR, "luse_stock_data.csv")) if os.path.exists(os.path.join(DATA_DIR, "luse_stock_data.csv")) else None
+        zafsa_data = pd.read_csv(os.path.join(DATA_DIR, "zafsa_data.csv")) if os.path.exists(os.path.join(DATA_DIR, "zafsa_data.csv")) else None
         
         # Merge data on date
         stock_data['date'] = pd.to_datetime(stock_data['date'])
         gold_price_data['date'] = pd.to_datetime(gold_price_data['date'])
         inflation_data['date'] = pd.to_datetime(inflation_data['date'])
+        if luse_data is not None:
+            luse_data["date"] = pd.to_datetime(luse_data["date"])
+        if zafsa_data is not None:
+            zafsa_data["date"] = pd.to_datetime(zafsa_data["date"])
         
         merged_data = pd.merge(stock_data, gold_price_data, on='date', how='inner')
         merged_data = pd.merge(merged_data, inflation_data, on='date', how='inner')
+        if luse_data is not None:
+            merged_data = pd.merge(merged_data, luse_data, on="date", how="left")
+        if zafsa_data is not None:
+            merged_data = pd.merge(merged_data, zafsa_data, on="date", how="left")
         
         # Save preprocessed data
         merged_data.to_csv(os.path.join(DATA_DIR, "merged_data.csv"), index=False)
@@ -85,6 +122,8 @@ def preprocess_data():
 def main():
     print(f"Pipeline started at {datetime.now()}")
     fetch_stock_data()
+    fetch_luse_stock_data()
+    fetch_zafsa_data()
     fetch_gold_price_data()
     fetch_inflation_data()
     preprocess_data()


### PR DESCRIPTION
## Summary
- add constants and API key env vars for LUSE and ZAFSA in `data_pipeline.py`
- fetch LUSE and ZAFSA data and merge with existing datasets
- document the optional integrations in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f48e78114832faf01036dd2cd589d