### PR TITLE
Add funeral operations toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ Other scripts require API keys as well:
 - `WEATHER_API_KEY` for `weather_dashboard.py`
 
 Ensure these variables are set in your environment before execution.
+
+## Funeral Operations Toolkit
+Scripts and documents for generating official communications related to a state funeral can be found in `funeral_ops/`.

--- a/funeral_ops/README.md
+++ b/funeral_ops/README.md
@@ -1,0 +1,13 @@
+# Funeral Operations Toolkit
+
+This folder contains scripts and documents related to the preparation of a State Funeral.
+
+- `generate_cabinet_circular.py` — Generates `cabinet_mobilization_circular.pdf` using ReportLab.
+- `state_funeral_press_statement.md` — Draft press statement in English and Bemba.
+- `broadcast_brief_script.md` — Script outline for an AU-format broadcast briefing.
+
+Run the following command to generate the circular:
+
+```bash
+python3 generate_cabinet_circular.py
+```

--- a/funeral_ops/broadcast_brief_script.md
+++ b/funeral_ops/broadcast_brief_script.md
@@ -1,0 +1,22 @@
+# AU-format Broadcast Brief
+
+**Purpose:**
+To outline the key points for a televised announcement on ZNBC, ZNDF, and to foreign missions across the African Union. The script may be recorded in HD with professional voiceover in English and Bemba.
+
+**Video Guidelines (HD 1080p):**
+1. Opening shot: National flag at half-mast.
+2. Transition to official portrait of the deceased.
+3. Presenter addresses the nation from a podium with Cabinet seal.
+4. Cutaway footage of preparations and condolence messages from regional leaders.
+5. Closing shot: Dates and times for the State Funeral.
+
+**Voiceover Script (English):**
+"Fellow citizens, it is with profound sorrow that we inform you of the passing of [Name of the Deceased]. The Government has initiated the National Mourning Protocol Framework. All ministries and agencies stand ready to honor our fallen leader. Further details will be shared after consultations with the family and our diplomatic partners."
+
+**Voiceover Script (Bemba):**
+"Bane benu, tufwile ukulanda uko twalililwa lelo. [Ishina lya fwile] twamwishiba kuti twalipwa. Government yasuma ico, yasala National Mourning Protocol Framework. Ballyuma lyonse bayanganepo pa mitendele no mutende. Ilyashi lyandi lyonse akalya landa muli Cabinet, tuleumfwana ne nshila shonse."
+
+**Distribution:**
+- ZNBC prime-time slot
+- ZNDF internal communications network
+- Embassy networks across the African Union

--- a/funeral_ops/generate_cabinet_circular.py
+++ b/funeral_ops/generate_cabinet_circular.py
@@ -1,0 +1,41 @@
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfgen import canvas
+
+
+def create_circular(output_path: str):
+    c = canvas.Canvas(output_path, pagesize=A4)
+    width, height = A4
+    text = c.beginText(40, height - 50)
+    text.setFont("Helvetica-Bold", 16)
+    text.textLine("Cabinet Mobilization Circular")
+    text.moveCursor(0, 20)
+
+    text.setFont("Helvetica", 12)
+    paragraphs = [
+        "Subject: National Funeral Operational Readiness",
+        "To: All Cabinet Ministers and Permanent Secretaries",
+        "",  # blank line
+        "This circular serves as official notification of the activation of the National Mourning Protocol Framework.",
+        "All ministries are required to lower national flags to half-mast within 48 hours and maintain this status until further notice.",
+        "Cabinet will convene to coordinate funeral rites, state honors, and inter-agency support.",
+        "ZAFSA and AIA will monitor all consular outputs and provide intelligence updates.",
+        "Military and diplomatic units must finalize escort planning for dignitaries.",
+        "The Ministry of Foreign Affairs and Ministry of Health are tasked with liaison and body transfer logistics.",
+        "ZNBC will prepare a national address and comply with Media Control Measures to suspend speculative broadcasts until cleared.",
+        "",  # blank line
+        "All ministries must appoint focal points and submit readiness reports within three days.",
+        "",  # blank line
+        "Signed,",
+        "Secretary to the Cabinet",
+    ]
+
+    for line in paragraphs:
+        text.textLine(line)
+
+    c.drawText(text)
+    c.showPage()
+    c.save()
+
+
+if __name__ == "__main__":
+    create_circular("cabinet_mobilization_circular.pdf")

--- a/funeral_ops/state_funeral_press_statement.md
+++ b/funeral_ops/state_funeral_press_statement.md
@@ -1,0 +1,17 @@
+# State Funeral Press Statement
+
+**English Version**
+
+We regret to announce the passing of [Name of the Deceased]. The Government of the Republic of Zambia has activated the National Mourning Protocol Framework. All flags will fly at half-mast as the nation prepares for the State Funeral.
+
+The Cabinet will convene to finalize funeral rites, military honors, and diplomatic arrangements. We urge the public to respect the family's privacy and await official updates through the Zambia National Broadcasting Corporation (ZNBC).
+
+Further details regarding the funeral program will be communicated in due course.
+
+**Bemba Version**
+
+Twalisakamana ukusuminisha ukubalilisha kwa [Ishina lya fwile]. Government ya Republic of Zambia yasala National Mourning Protocol Framework. Amalubilo yonse yafwile yaleke kusanswa pa katikati mu maawa makumi aifyafulwa.
+
+Cabinet ilayikala ukupanga ifya malilo, ubwina bwa sesheke, na filya fyapama diplomatic. Twasabombe abantu bonse balemona ukusunga umulilo no kulekwesha amaka ku lintu baleleka abakulu mu ZNBC batuletele kuisebanya.
+
+Ifyo fine fya malilo filatwisha ukulikilwa mu calo bonse.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ django==4.2.1         # For building web applications (optional)
 requests==2.31.0      # For making HTTP requests
 beautifulsoup4==4.12.2  # For web scraping (if applicable)
 pytest==7.4.0         # For testing framework
+reportlab==3.6.12  # For PDF generation


### PR DESCRIPTION
## Summary
- add scripts to manage a state funeral in `funeral_ops/`
- explain usage in the new folder README
- mention funeral toolkit in root README
- add `reportlab` to dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bb79089c832f9979d7cf24c73e55